### PR TITLE
Accept and use params in method missing along with update scoped key

### DIFF
--- a/lib/rails-settings/base.rb
+++ b/lib/rails-settings/base.rb
@@ -26,25 +26,27 @@ module RailsSettings
       def cache_key(var_name, scope_object)
         scope = ['rails_settings_cached', cache_prefix_by_startup]
         scope << @cache_prefix.call if @cache_prefix
-        scope << "#{scope_object.class.name}-#{scope_object.id}" if scope_object
+        scope << "#{scope_object.class.base_class.to_s}-#{scope_object.id}" if scope_object
         scope << var_name.to_s
         scope.join('/')
       end
 
-      def [](key)
-        settings_key = scoped_key(key)
-        return super(settings_key) unless rails_initialized?
-        val = Rails.cache.fetch(cache_key(settings_key, @object)) do
-          super(settings_key)
+      def [](key, object = nil)
+        settings_key = scoped_key(key, object)
+        object ||= @object
+        return super(settings_key, object) unless rails_initialized?
+        val = Rails.cache.fetch(cache_key(settings_key, object)) do
+          super(settings_key, object)
         end
         val
       end
 
       # set a setting value by [] notation
-      def []=(var_name, value)
-        settings_key = scoped_key(var_name)
-        super(settings_key, value)
-        Rails.cache.write(cache_key(settings_key, @object), value)
+      def []=(var_name, value, object = nil)
+        settings_key = scoped_key(var_name, object)
+        object ||= @object
+        super(settings_key, value, object)
+        Rails.cache.write(cache_key(settings_key, object), value)
         value
       end
 
@@ -55,13 +57,16 @@ module RailsSettings
       #
       # @return [String] key with the model's scope applied to it
       #
-      def scoped_key(key)
-        @settings_scope.blank? ? key : "#{@settings_scope.to_s}.#{key}"
+      def scoped_key(key, object = nil)
+        output = key
+        output = "#{@settings_scope.to_s}.#{key}" if @settings_scope.present?
+        output = "#{object.class.base_class.to_s.downcase}.#{key}" if object.present?
+
+        output
       end
 
       def save_default(key, value)
-        Kernel.warn 'DEPRECATION WARNING: RailsSettings save_default is deprecated and it will removed in 0.7.0. ' <<
-                    'Please use YAML file for default setting.'
+        Kernel.warn 'DEPRECATION WARNING: RailsSettings save_default is deprecated and it will removed in 0.7.0. ' << 'Please use YAML file for default setting.'
         return false unless self[key].nil?
         self[key] = value
       end

--- a/lib/rails-settings/version.rb
+++ b/lib/rails-settings/version.rb
@@ -1,7 +1,7 @@
 module RailsSettings
   class << self
     def version
-      '0.6.5'
+      '0.6.6'
     end
   end
 end


### PR DESCRIPTION
Issue with rails caching for settings.   

--- 

# Why?
<!-- 
==============================================================
DESCRIBE HERE WHY ARE YOU DOING THIS PR, SOMETIMES THE JIRA 
DESCRIPTION WILL WORK, SOMETIMES DONT. YOU REALLY NEED TO 
UNDERSTAND WHY YOU ARE DOING SOMETHING.
==============================================================
-->
Issue with rails caching for settings.

# What?
<!-- 
==============================================================
DESCRIBE HERE WHAT YOU DID TO SATISFY THE WHY. IT CAN BE A
LIST OF CHANGES YOU DID OR THINGS YOU CREATED
==============================================================
-->
- Now settings method should include object as parameter to always consider the fetch in done for the object(partner).
- Old way of using settings still possible but not recommended. (e.g. `@partner.settings.is_spa`)
- New recommended way would be to pass `@partner` as params to be handled by `method_missing` function
  `@partner.settings.is_spa(@partner)` or `Setting.is_spa(@partner)`.
- Updated scoped key for object params and cache key.
- Used object's base class name to avoid use of decorative class names.
